### PR TITLE
Add workaround for buggy emblaze plugin

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -70,7 +70,9 @@ echo 'ServerName flashpointvm' >>/etc/apache2/httpd.conf
 echo 'SetEnv force-response-1.0' >>/etc/apache2/httpd.conf # required for certain Shockwave games, thanks Tomy
 echo 'SetEnvIf Remote_Addr "::1" dontlog' >>/etc/apache2/httpd.conf # disable logging of Apache's dummy connections
 echo 'ProxyPreserveHost On' >>/etc/apache2/httpd.conf # keep "Host" header when proxying requests to legacy server
-
+echo '<FilesMatch "\.(blz)$">' >>/etc/apache2/httpd.conf # work around buggy emblaze plugin
+echo 'Header unset ETag' >>/etc/apache2/httpd.conf
+echo '</FilesMatch>' >>/etc/apache2/httpd.conf
 # hack: fix mime types for requests from legacy server
 sed -i 's/exe dll com bat msi/exe dll bat msi/g' /etc/apache2/mime.types
 sed -i 's|application/vnd.lotus-organizer|# application/vnd.lotus-organizer|g' /etc/apache2/mime.types


### PR DESCRIPTION
Emblaze doesn't properly handle getting very small amounts of data in the first npapi transfer.  Netscape 4 win16 first does recv with 260 bytes requested.  Since the http headers are 256 bytes that leaves 4 bytes to pass to the plugin which expects more and assumes the junk data past the end of the buffer is part of the file and crashes the browser in the process.  Removing the etag header (which isn't itself a problem) frees enough space in the first transfer to satisfy the plugin.
CC @VFDan 