### PR TITLE
Move the snapshot to a separate disk.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         draft: false
         prerelease: false
     - name: Upload alpine.qcow2
-      id: upload_release
+      id: upload_alpine
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
         asset_name: alpine.qcow2
         asset_content_type: application/octet-stream
     - name: Upload dummy.qcow2
-      id: upload_release
+      id: upload_dummy
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         release_name: ${{ steps.prepare.outputs.sha_short }}
         draft: false
         prerelease: false
-    - name: Upload release
+    - name: Upload alpine.qcow2
       id: upload_release
       uses: actions/upload-release-asset@v1
       env:
@@ -42,4 +42,14 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./alpine.qcow2
         asset_name: alpine.qcow2
+        asset_content_type: application/octet-stream
+    - name: Upload dummy.qcow2
+      id: upload_release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./dummy.qcow2
+        asset_name: dummy.qcow2
         asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,13 @@ jobs:
         asset_path: ./alpine.qcow2
         asset_name: alpine.qcow2
         asset_content_type: application/octet-stream
-    - name: Upload dummy.qcow2
-      id: upload_dummy
+    - name: Upload snapshot.qcow2
+      id: upload_snapshot
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./dummy.qcow2
-        asset_name: dummy.qcow2
+        asset_path: ./snapshot.qcow2
+        asset_name: snapshot.qcow2
         asset_content_type: application/octet-stream

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+rm -f dummy.qcow2
+qemu-img create -f qcow2 dummy.qcow2 1M
 qemu-system-i386 $QEMU_EXTRA_ARGS -display none -m 128 \
 -net 'nic,model=virtio-net-pci' -net 'user,hostfwd=tcp::22500-:80' \
--monitor 'tcp:localhost:4445,server,nowait' -drive 'file=alpine.qcow2,if=virtio' &
+-monitor 'tcp:localhost:4445,server,nowait' -drive 'if=none,format=qcow2,file=dummy.qcow2' \
+-drive 'file=alpine.qcow2,if=virtio' &
 pid=$!
 
 while ! curl -sI 'http://127.0.0.1:22500/' >/dev/null; do
@@ -10,4 +13,5 @@ done
 
 echo 'apache is ready .. snapshot in 10 seconds' && sleep 10
 echo 'savevm quick' | nc -q1 -w5 127.0.0.1 4445 >/dev/null
-kill -TERM "$pid"
+sleep 2
+echo 'quit' | nc -q1 -w5 127.0.0.1 4445 >/dev/null

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-rm -f dummy.qcow2
-qemu-img create -f qcow2 dummy.qcow2 1M
+rm -f snapshot.qcow2
+qemu-img create -f qcow2 snapshot.qcow2 1M
 qemu-system-i386 $QEMU_EXTRA_ARGS -display none -m 128 \
 -net 'nic,model=virtio-net-pci' -net 'user,hostfwd=tcp::22500-:80' \
--monitor 'tcp:localhost:4445,server,nowait' -drive 'if=none,format=qcow2,file=dummy.qcow2' \
+-monitor 'tcp:localhost:4445,server,nowait' -drive 'if=none,format=qcow2,file=snapshot.qcow2' \
 -drive 'file=alpine.qcow2,if=virtio' &
 pid=$!
 


### PR DESCRIPTION
Merge #10 first.

QEMU only allows snapshot loading from writable devices. Without a separation of snapshot data from image data, this would make a read-only `alpine.qcow2` impossible.
Instead, we can attach `alpine.qcow2` read-only at runtime, and load the snapshot from the writable `snapshot.qcow2`, e.g. `qemu-system-i386 -machine pc-i440fx-5.2 -m 128 -net nic,model=virtio-net-pci -net user,hostfwd=tcp:127.0.0.1:22500-:80 -qmp tcp:127.0.0.1:4444,server,nowait -qmp tcp:127.0.0.1:4445,server,nowait -drive if=none,format=qcow2,file=snapshot.qcow2 -drive file=alpine.qcow2,if=virtio,readonly=on -serial stdio -loadvm quick -display none`.

The updated `arguments` list in `services.json` should be:
```json
[
  "-machine",
  "pc-i440fx-5.2",
  "-m",
  "128",
  "-net",
  "nic,model=virtio-net-pci",
  "-net",
  "user,hostfwd=tcp:127.0.0.1:22500-:80",
  "-qmp",
  "tcp:127.0.0.1:4444,server,nowait",
  "-qmp",
  "tcp:127.0.0.1:4445,server,nowait",
  "-drive",
  "if=none,format=qcow2,file=snapshot.qcow2",
  "-drive",
  "file=alpine.qcow2,if=virtio,readonly=on",
  "-serial",
  "stdio",
  "-loadvm",
  "quick",
  "-display",
  "none"
]
```